### PR TITLE
Update screen recorder handler to fix ConcurrentModificationException

### DIFF
--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderHandler.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderHandler.kt
@@ -1,14 +1,24 @@
 package com.malinskiy.marathon.android.executor.listeners.video
 
+import java.util.concurrent.CopyOnWriteArrayList
+
 class ScreenRecorderHandler {
 
-    private val listeners: MutableList<() -> Unit> = arrayListOf()
+    private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
+
+    @Volatile
+    private var stopped: Boolean = false
 
     fun stop() {
+        stopped = true
         listeners.forEach { it() }
     }
 
     fun subscribeOnStop(onStop: () -> Unit) {
-        listeners += onStop
+        if (stopped) {
+            onStop()
+        } else {
+            listeners += onStop
+        }
     }
 }


### PR DESCRIPTION
```
java.util.ConcurrentModificationException
[16:52:50]W:	 [Step 4/6] 	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
[16:52:50]W:	 [Step 4/6] 	at java.util.ArrayList$Itr.next(ArrayList.java:859)
[16:52:50]W:	 [Step 4/6] 	at com.malinskiy.marathon.android.executor.listeners.video.ScreenRecorderHandler.stop(ScreenRecorderHandler.kt:16)
[16:52:50]W:	 [Step 4/6] 	at com.malinskiy.marathon.android.executor.listeners.video.ScreenRecorderTestRunListener.testEnded(ScreenRecorderTestRunListener.kt:58)
[16:52:50]W:	 [Step 4/6] 	at com.malinskiy.marathon.android.executor.listeners.CompositeTestRunListener.testEnded(CompositeTestRunListener.kt:31)
[16:52:50]W:	 [Step 4/6] 	at com.malinskiy.marathon.android.ddmlib.DdmlibTestRunListener.testEnded(DdmlibTestRunListener.kt:34)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.testrunner.InstrumentationResultParser.reportResult(InstrumentationResultParser.java:548)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.testrunner.InstrumentationResultParser.parseStatusCode(InstrumentationResultParser.java:454)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.testrunner.InstrumentationResultParser.parse(InstrumentationResultParser.java:307)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.testrunner.InstrumentationResultParser.processNewLines(InstrumentationResultParser.java:278)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.MultiLineReceiver.addOutput(MultiLineReceiver.java:104)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.AdbHelper.executeRemoteCommand(AdbHelper.java:568)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.AdbHelper.executeRemoteCommand(AdbHelper.java:378)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.Device.executeShellCommand(Device.java:673)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.testrunner.RemoteAndroidTestRunner.run(RemoteAndroidTestRunner.java:285)
[16:52:50]W:	 [Step 4/6] 	at com.android.ddmlib.testrunner.RemoteAndroidTestRunner.run(RemoteAndroidTestRunner.java:270)
[16:52:50]W:	 [Step 4/6] 	at com.malinskiy.marathon.android.ddmlib.AndroidDeviceTestRunner.execute(AndroidDeviceTestRunner.kt:52)
[16:52:50]W:	 [Step 4/6] 	at com.malinskiy.marathon.android.ddmlib.DdmlibAndroidDevice$execute$deferredResult$1.invokeSuspend(DdmlibAndroidDevice.kt:288)
[16:52:50]W:	 [Step 4/6] 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
[16:52:50]W:	 [Step 4/6] 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
[16:52:50]W:	 [Step 4/6] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[16:52:50]W:	 [Step 4/6] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[16:52:50]W:	 [Step 4/6] 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
[16:52:50]W:	 [Step 4/6] 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
[16:52:50]W:	 [Step 4/6] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[16:52:50]W:	 [Step 4/6] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[16:52:50]W:	 [Step 4/6] 	at java.lang.Thread.run(Thread.java:748)
[16:52:51]W:	 [Step 4/6] Error Parent job is Cancelling
```