### PR TITLE
Include stacktrace failures in incomplete filter

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -37,7 +37,7 @@ data class FileConfiguration(
     var testClassRegexes: Collection<Regex>?,
     var includeSerialRegexes: Collection<Regex>?,
     var excludeSerialRegexes: Collection<Regex>?,
-    var ignoreCrashRegexes: Collection<Regex>?,
+    var ignoreFailureRegexes: Collection<Regex>?,
 
     var testBatchTimeoutMillis: Long?,
     var testOutputTimeoutMillis: Long?,

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -64,7 +64,7 @@ class ConfigFactory(private val mapper: ObjectMapper) {
             testClassRegexes = config.testClassRegexes,
             includeSerialRegexes = config.includeSerialRegexes,
             excludeSerialRegexes = config.excludeSerialRegexes,
-            ignoreCrashRegexes = config.ignoreCrashRegexes,
+            ignoreFailureRegexes = config.ignoreFailureRegexes,
             testBatchTimeoutMillis = config.testBatchTimeoutMillis,
             testOutputTimeoutMillis = config.testOutputTimeoutMillis,
             noDevicesTimeoutMillis = config.noDevicesTimeoutMillis,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -86,7 +86,7 @@ data class Configuration constructor(
         testClassRegexes: Collection<Regex>?,
         includeSerialRegexes: Collection<Regex>?,
         excludeSerialRegexes: Collection<Regex>?,
-        ignoreCrashRegexes: Collection<Regex>?,
+        ignoreFailureRegexes: Collection<Regex>?,
 
         testBatchTimeoutMillis: Long?,
         testOutputTimeoutMillis: Long?,
@@ -121,7 +121,7 @@ data class Configuration constructor(
             testClassRegexes = testClassRegexes ?: listOf(Regex("^((?!Abstract).)*Test$")),
             includeSerialRegexes = includeSerialRegexes ?: emptyList(),
             excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),
-            ignoreFailureRegexes = ignoreCrashRegexes ?: emptyList(),
+            ignoreFailureRegexes = ignoreFailureRegexes ?: emptyList(),
             testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,
             testOutputTimeoutMillis = testOutputTimeoutMillis ?: DEFAULT_OUTPUT_TIMEOUT_MILLIS,
             noDevicesTimeoutMillis = noDevicesTimeoutMillis ?: DEFAULT_NO_DEVICES_TIMEOUT_MILLIS,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -47,7 +47,7 @@ data class Configuration constructor(
     val testClassRegexes: Collection<Regex>,
     val includeSerialRegexes: Collection<Regex>,
     val excludeSerialRegexes: Collection<Regex>,
-    val ignoreCrashRegexes: Collection<Regex>,
+    val ignoreFailureRegexes: Collection<Regex>,
 
     val testBatchTimeoutMillis: Long,
     val testOutputTimeoutMillis: Long,
@@ -121,7 +121,7 @@ data class Configuration constructor(
             testClassRegexes = testClassRegexes ?: listOf(Regex("^((?!Abstract).)*Test$")),
             includeSerialRegexes = includeSerialRegexes ?: emptyList(),
             excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),
-            ignoreCrashRegexes = ignoreCrashRegexes ?: emptyList(),
+            ignoreFailureRegexes = ignoreCrashRegexes ?: emptyList(),
             testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,
             testOutputTimeoutMillis = testOutputTimeoutMillis ?: DEFAULT_OUTPUT_TIMEOUT_MILLIS,
             noDevicesTimeoutMillis = noDevicesTimeoutMillis ?: DEFAULT_NO_DEVICES_TIMEOUT_MILLIS,

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/ConfigurationFactory.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/ConfigurationFactory.kt
@@ -107,7 +107,7 @@ private fun createConfiguration(
     testClassRegexes = extensionConfig.testClassRegexes?.map { it.toRegex() },
     includeSerialRegexes = extensionConfig.includeSerialRegexes?.map { it.toRegex() },
     excludeSerialRegexes = extensionConfig.excludeSerialRegexes?.map { it.toRegex() },
-    ignoreCrashRegexes = extensionConfig.ignoreFailureRegexes?.map { it.toRegex(RegexOption.DOT_MATCHES_ALL) },
+    ignoreFailureRegexes = extensionConfig.ignoreFailureRegexes?.map { it.toRegex(RegexOption.DOT_MATCHES_ALL) },
     testBatchTimeoutMillis = extensionConfig.testBatchTimeoutMillis,
     testOutputTimeoutMillis = extensionConfig.testOutputTimeoutMillis,
     noDevicesTimeoutMillis = extensionConfig.noDevicesTimeoutMillis,

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/ConfigurationFactory.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/ConfigurationFactory.kt
@@ -107,7 +107,7 @@ private fun createConfiguration(
     testClassRegexes = extensionConfig.testClassRegexes?.map { it.toRegex() },
     includeSerialRegexes = extensionConfig.includeSerialRegexes?.map { it.toRegex() },
     excludeSerialRegexes = extensionConfig.excludeSerialRegexes?.map { it.toRegex() },
-    ignoreCrashRegexes = extensionConfig.ignoreCrashRegexes?.map { it.toRegex(RegexOption.DOT_MATCHES_ALL) },
+    ignoreCrashRegexes = extensionConfig.ignoreFailureRegexes?.map { it.toRegex(RegexOption.DOT_MATCHES_ALL) },
     testBatchTimeoutMillis = extensionConfig.testBatchTimeoutMillis,
     testOutputTimeoutMillis = extensionConfig.testOutputTimeoutMillis,
     noDevicesTimeoutMillis = extensionConfig.noDevicesTimeoutMillis,

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -32,7 +32,7 @@ open class MarathonExtension(project: Project) {
     var testClassRegexes: Collection<String>? = null
     var includeSerialRegexes: Collection<String>? = null
     var excludeSerialRegexes: Collection<String>? = null
-    var ignoreCrashRegexes: Collection<String>? = null
+    var ignoreFailureRegexes: Collection<String>? = null
 
     var testBatchTimeoutMillis: Long? = null
     var testOutputTimeoutMillis: Long? = null

--- a/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
+++ b/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
@@ -41,7 +41,7 @@ class AndroidTestParserSpek : Spek(
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
-                    ignoreCrashRegexes = null,
+                    ignoreFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
@@ -74,7 +74,7 @@ class AndroidDeviceTestRunnerSpek : Spek(
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
-                    ignoreCrashRegexes = null,
+                    ignoreFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
@@ -92,7 +92,7 @@ object DerivedDataManagerSpek : Spek(
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
-                    ignoreCrashRegexes = null,
+                    ignoreFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
@@ -44,7 +44,7 @@ object IOSTestParserSpek : Spek(
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
-                    ignoreCrashRegexes = null,
+                    ignoreFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
@@ -39,7 +39,7 @@ class ConfigurationFactory {
     var customAnalyticsTracker: Tracker? = null
     var analyticsConfiguration: AnalyticsConfiguration? = null
     var excludeSerialRegexes: List<Regex>? = null
-    var ignoreCrashRegexes: List<Regex>? = null
+    var ignoreFailureRegexes: List<Regex>? = null
     var fallbackToScreenshots: Boolean? = null
     var strictMode: Boolean? = null
     var uncompletedTestRetryQuota: Int? = null
@@ -97,7 +97,7 @@ class ConfigurationFactory {
             testClassRegexes = testClassRegexes,
             includeSerialRegexes = includeSerialRegexes,
             excludeSerialRegexes = excludeSerialRegexes,
-            ignoreCrashRegexes = ignoreCrashRegexes,
+            ignoreFailureRegexes = ignoreFailureRegexes,
             testBatchTimeoutMillis = testBatchTimeoutMillis,
             testOutputTimeoutMillis = testOutputTimeoutMillis,
             noDevicesTimeoutMillis = noDevicesTimeoutMillis,


### PR DESCRIPTION
Previously crash filter option only included crash events from LogCat, now it includes stacktrace of test failure as well.