### PR TITLE
Fix for android freeze when batch consists only of ignored tests

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -266,7 +266,7 @@ class QueueActor(
             } else {
                 logger.debug { "queue is empty and stop is not requested yet, no batches available for ${device.serialNumber}" }
             }
-        } else {
+        } else if (queueIsEmpty) {
             logger.debug {
                 "queue is empty but there are active batches present for " +
                     activeBatches.keys.joinToString { it }

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -13,14 +13,13 @@ import com.malinskiy.marathon.android.InstrumentationInfo
 import com.malinskiy.marathon.exceptions.DeviceLostException
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.log.MarathonLogging
-import com.malinskiy.marathon.test.MetaProperty
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
 import com.malinskiy.marathon.test.toTestName
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
-val JUNIT_IGNORE_META_PROPERY = MetaProperty("org.junit.Ignore")
+const val JUNIT_IGNORE_META_PROPERY = "org.junit.Ignore"
 const val ERROR_STUCK = "Test got stuck. You can increase the timeout in settings if it's too strict"
 
 class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
@@ -34,7 +33,10 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
     ) {
         val androidComponentInfo = rawTestBatch.componentInfo as AndroidComponentInfo
 
-        val ignoredTests = rawTestBatch.tests.filter { it.metaProperties.contains(JUNIT_IGNORE_META_PROPERY) }
+        val ignoredTests = rawTestBatch.tests.filter { test ->
+            test.metaProperties.any { it.name == JUNIT_IGNORE_META_PROPERY }
+        }
+
         val testBatch = TestBatch(
             id = rawTestBatch.id,
             tests = rawTestBatch.tests - ignoredTests,


### PR DESCRIPTION
Fix of incorrect ignored test filtering. And report queue is empty when it's actually empty