### PR TITLE
Move test execution from buildFinished callback to a task

### DIFF
--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonPlugin.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonPlugin.kt
@@ -62,98 +62,95 @@ class MarathonPlugin : Plugin<Project> {
         }
     }
 
-    companion object {
+    private fun Project.setUpWorker() {
+        if (project.rootProject.extensions.findByName(EXTENSION_NAME) == null) {
+            project.rootProject.extensions.create(EXTENSION_NAME, MarathonExtension::class.java, project.rootProject)
 
-        private fun Project.setUpWorker() {
-            if (project.rootProject.extensions.findByName(EXTENSION_NAME) == null) {
-                project.rootProject.extensions.create(EXTENSION_NAME, MarathonExtension::class.java, project.rootProject)
+            gradle.projectsEvaluated {
+                val configuration = createCommonConfiguration(project.rootProject, EXTENSION_NAME, androidSdkLocation)
+                MarathonWorker.initialize(configuration)
+            }
 
-                gradle.projectsEvaluated {
-                    val configuration = createCommonConfiguration(project.rootProject, EXTENSION_NAME, androidSdkLocation)
-                    MarathonWorker.initialize(configuration)
-                }
-
-                gradle.buildFinished {
-                    MarathonWorker.stop()
-                }
+            gradle.buildFinished {
+                MarathonWorker.stop()
             }
         }
+    }
 
-        private fun registerTask(
-            variant: TestVariant,
-            project: Project,
-            properties: MarathonProperties,
-            baseExtension: BaseExtension
-        ): TaskProvider<out DefaultTask> {
-            checkTestVariants(variant)
+    private fun registerTask(
+        variant: TestVariant,
+        project: Project,
+        properties: MarathonProperties,
+        baseExtension: BaseExtension
+    ): TaskProvider<out DefaultTask> {
+        checkTestVariants(variant)
 
-            val taskType =
-                if (properties.isCommonWorkerEnabled) MarathonScheduleTestsToWorkerTask::class.java else MarathonRunTask::class.java
-            val marathonTask = project.tasks.register("$TASK_PREFIX${variant.name.capitalize()}", taskType)
+        val taskType =
+            if (properties.isCommonWorkerEnabled) MarathonScheduleTestsToWorkerTask::class.java else MarathonRunTask::class.java
+        val marathonTask = project.tasks.register("$TASK_PREFIX${variant.name.capitalize()}", taskType)
+
+        marathonTask.configure {
+            group = JavaBasePlugin.VERIFICATION_GROUP
+            description = "Runs instrumentation tests on all the connected devices for '${variant.name}' " +
+                "variation and generates a report with screenshots"
+            outputs.upToDateWhen { false }
+            dependsOn(variant.testedVariant.assembleProvider, variant.assembleProvider)
+        }
+
+        variant.testedVariant.outputs.all {
+            val testedOutput = this
+
+            checkTestedVariants(testedOutput)
 
             marathonTask.configure {
-                group = JavaBasePlugin.VERIFICATION_GROUP
-                description = "Runs instrumentation tests on all the connected devices for '${variant.name}' " +
-                    "variation and generates a report with screenshots"
-                outputs.upToDateWhen { false }
-                dependsOn(variant.testedVariant.assembleProvider, variant.assembleProvider)
-            }
-
-            variant.testedVariant.outputs.all {
-                val testedOutput = this
-
-                checkTestedVariants(testedOutput)
-
-                marathonTask.configure {
-                    if (properties.isCommonWorkerEnabled) {
-                        val componentInfo = createComponentInfo(
-                            project = project,
-                            flavorName = variant.name,
-                            applicationVariant = variant.testedVariant,
-                            testVariant = variant
-                        )
-                        (this as MarathonScheduleTestsToWorkerTask).componentInfo = componentInfo
-                    } else {
-                        val config = createConfiguration(
-                            marathonExtensionName = EXTENSION_NAME,
-                            project = project,
-                            sdkDirectory = baseExtension.sdkDirectory,
-                            flavorName = variant.name,
-                            applicationVariant = variant.testedVariant,
-                            testVariant = variant
-                        )
-                        (this as MarathonRunTask).configuration = config
-                    }
+                if (properties.isCommonWorkerEnabled) {
+                    val componentInfo = createComponentInfo(
+                        project = project,
+                        flavorName = variant.name,
+                        applicationVariant = variant.testedVariant,
+                        testVariant = variant
+                    )
+                    (this as MarathonScheduleTestsToWorkerTask).componentInfo = componentInfo
+                } else {
+                    val config = createConfiguration(
+                        marathonExtensionName = EXTENSION_NAME,
+                        project = project,
+                        sdkDirectory = baseExtension.sdkDirectory,
+                        flavorName = variant.name,
+                        applicationVariant = variant.testedVariant,
+                        testVariant = variant
+                    )
+                    (this as MarathonRunTask).configuration = config
                 }
             }
-
-            return marathonTask
         }
 
-        private fun checkTestVariants(testVariant: TestVariant) {
-            if (testVariant.outputs.size > 1) {
-                throw UnsupportedOperationException("The Marathon plugin does not support abi/density splits for test APKs")
-            }
+        return marathonTask
+    }
 
+    private fun checkTestVariants(testVariant: TestVariant) {
+        if (testVariant.outputs.size > 1) {
+            throw UnsupportedOperationException("The Marathon plugin does not support abi/density splits for test APKs")
         }
+    }
 
-        /**
-         * Checks that if the base variant contains more than one outputs (and has therefore splits), it is the universal APK.
-         * Otherwise, we can test the single output. This is a workaround until Fork supports test & app splits properly.
-         *
-         * @param baseVariant the tested variant
-         */
-        private fun checkTestedVariants(baseVariantOutput: BaseVariantOutput) {
-            if (baseVariantOutput.outputs.size > 1) {
-                throw UnsupportedOperationException(
-                    "The Marathon plugin does not support abi splits for app APKs, " +
-                        "but supports testing via a universal APK. "
-                        + "Add the flag \"universalApk true\" in the android.splits.abi configuration."
-                )
-            }
-
+    /**
+     * Checks that if the base variant contains more than one outputs (and has therefore splits), it is the universal APK.
+     * Otherwise, we can test the single output. This is a workaround until Fork supports test & app splits properly.
+     *
+     * @param baseVariant the tested variant
+     */
+    private fun checkTestedVariants(baseVariantOutput: BaseVariantOutput) {
+        if (baseVariantOutput.outputs.size > 1) {
+            throw UnsupportedOperationException(
+                "The Marathon plugin does not support abi splits for app APKs, " +
+                    "but supports testing via a universal APK. "
+                    + "Add the flag \"universalApk true\" in the android.splits.abi configuration."
+            )
         }
+    }
 
+    companion object {
         /**
          * Task name prefix.
          */

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonPlugin.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonPlugin.kt
@@ -22,8 +22,10 @@ class MarathonPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val properties = project.rootProject.marathonProperties
 
-        if (properties.isCommonWorkerEnabled) {
+        val marathonWorkerTask = if (properties.isCommonWorkerEnabled) {
             project.setUpWorker()
+        } else {
+            null
         }
 
         if (project.extensions.findByName(EXTENSION_NAME) == null) {
@@ -57,13 +59,18 @@ class MarathonPlugin : Plugin<Project> {
 
             testedExtension!!.testVariants.all {
                 val testTaskForVariant = registerTask(this, project, properties, testedExtension)
-                marathonTask.configure { dependsOn(testTaskForVariant) }
+                marathonTask.configure {
+                    dependsOn(testTaskForVariant)
+                    if (marathonWorkerTask != null) {
+                        finalizedBy(marathonWorkerTask)
+                    }
+                }
             }
         }
     }
 
-    private fun Project.setUpWorker() {
-        if (project.rootProject.extensions.findByName(EXTENSION_NAME) == null) {
+    private fun Project.setUpWorker(): TaskProvider<MarathonWorkerRunTask> {
+        return if (project.rootProject.extensions.findByName(EXTENSION_NAME) == null) {
             project.rootProject.extensions.create(EXTENSION_NAME, MarathonExtension::class.java, project.rootProject)
 
             gradle.projectsEvaluated {
@@ -71,9 +78,9 @@ class MarathonPlugin : Plugin<Project> {
                 MarathonWorker.initialize(configuration)
             }
 
-            gradle.buildFinished {
-                MarathonWorker.stop()
-            }
+            project.rootProject.tasks.register(WORKER_TASK_NAME, MarathonWorkerRunTask::class.java)
+        } else {
+            project.rootProject.tasks.named(WORKER_TASK_NAME, MarathonWorkerRunTask::class.java)
         }
     }
 
@@ -157,5 +164,6 @@ class MarathonPlugin : Plugin<Project> {
         private const val TASK_PREFIX = "marathon"
 
         private const val EXTENSION_NAME = "marathon"
+        private const val WORKER_TASK_NAME = "marathonRun"
     }
 }

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonWorkerRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonWorkerRunTask.kt
@@ -1,0 +1,12 @@
+package com.malinskiy.marathon
+
+import com.malinskiy.marathon.worker.MarathonWorker
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+abstract class MarathonWorkerRunTask : DefaultTask() {
+    @TaskAction
+    fun run() {
+        MarathonWorker.stop()
+    }
+}

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonWorkerRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonWorkerRunTask.kt
@@ -7,6 +7,6 @@ import org.gradle.api.tasks.TaskAction
 abstract class MarathonWorkerRunTask : DefaultTask() {
     @TaskAction
     fun run() {
-        MarathonWorker.stop()
+        MarathonWorker.await()
     }
 }

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/worker/MarathonWorker.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/worker/MarathonWorker.kt
@@ -13,9 +13,9 @@ object MarathonWorker : WorkerHandler {
 
     override fun scheduleTests(componentInfo: ComponentInfo) = context.scheduleTests(componentInfo)
 
-    override fun stop() {
+    override fun await() {
         try {
-            context.stop()
+            context.await()
         } finally {
             // re-create context to clear the reference for future runs
             context = WorkerContext()

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/worker/WorkerContext.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/worker/WorkerContext.kt
@@ -40,7 +40,7 @@ class WorkerContext : WorkerHandler {
         componentsChannel.offer(componentInfo)
     }
 
-    override fun stop() {
+    override fun await() {
         if (isRunning.get()) {
             startedLatch.await(WAITING_FOR_START_TIMEOUT_MINUTES, TimeUnit.MINUTES)
             componentsChannel.close()

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/worker/WorkerHandler.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/worker/WorkerHandler.kt
@@ -7,5 +7,5 @@ interface WorkerHandler {
     fun initialize(configuration: Configuration)
     fun ensureStarted()
     fun scheduleTests(componentInfo: ComponentInfo)
-    fun stop()
+    fun await()
 }


### PR DESCRIPTION
This change will make it possible to connect the test execution task with other tasks, e.g. disconnect emulators in another task that waits for the test execution to complete.

Also in the rich console it's now a bit more clear what's happening.
Before:
<img width="255" alt="Screenshot 2021-07-26 at 14 47 20" src="https://user-images.githubusercontent.com/119192/127000080-8958f4bd-f509-489e-9a38-16e9e52975ac.png">
After:
<img width="250" alt="Screenshot 2021-07-26 at 14 45 32" src="https://user-images.githubusercontent.com/119192/127000104-d4f9f304-71ac-4d82-bdbe-09bef06dda48.png">
