### PR TITLE
Add "failFastFailureRegexes" property, like anti-"ignoreFailureRegexes"

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     val ktor = "1.6.5"
 
     val ddmlib = "30.1.2"
-    val dexTestParser = "830520963019a6cefada34fc5eb396003c1468d5" // contains patch https://github.com/linkedin/dex-test-parser/pull/46
+    val dexTestParser = "2.3.4"
     val kotlinLogging = "1.4.9"
     val slf4jAPI = "1.0.0"
     val logbackClassic = "1.2.3"
@@ -54,7 +54,7 @@ object BuildPlugins {
 object Libraries {
     val ddmlib = "com.android.tools.ddms:ddmlib:${Versions.ddmlib}"
     val androidCommon = "com.android.tools:common:${Versions.ddmlib}"
-    val dexTestParser = "com.github.lukaville:dex-test-parser:${Versions.dexTestParser}"
+    val dexTestParser = "com.linkedin.dextestparser:parser:${Versions.dexTestParser}"
     val kotlinBom = "org.jetbrains.kotlin:kotlin-bom"
     val kotlinCoroutinesBom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:${Versions.coroutines}"
     val kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect"

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -38,6 +38,7 @@ data class FileConfiguration(
     var includeSerialRegexes: Collection<Regex>?,
     var excludeSerialRegexes: Collection<Regex>?,
     var ignoreFailureRegexes: Collection<Regex>?,
+    var failFastFailureRegexes: Collection<Regex>?,
 
     var testBatchTimeoutMillis: Long?,
     var testOutputTimeoutMillis: Long?,

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -65,6 +65,7 @@ class ConfigFactory(private val mapper: ObjectMapper) {
             includeSerialRegexes = config.includeSerialRegexes,
             excludeSerialRegexes = config.excludeSerialRegexes,
             ignoreFailureRegexes = config.ignoreFailureRegexes,
+            failFastFailureRegexes = config.failFastFailureRegexes,
             testBatchTimeoutMillis = config.testBatchTimeoutMillis,
             testOutputTimeoutMillis = config.testOutputTimeoutMillis,
             noDevicesTimeoutMillis = config.noDevicesTimeoutMillis,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -48,6 +48,7 @@ data class Configuration constructor(
     val includeSerialRegexes: Collection<Regex>,
     val excludeSerialRegexes: Collection<Regex>,
     val ignoreFailureRegexes: Collection<Regex>,
+    val failFastFailureRegexes: Collection<Regex>,
 
     val testBatchTimeoutMillis: Long,
     val testOutputTimeoutMillis: Long,
@@ -87,6 +88,7 @@ data class Configuration constructor(
         includeSerialRegexes: Collection<Regex>?,
         excludeSerialRegexes: Collection<Regex>?,
         ignoreFailureRegexes: Collection<Regex>?,
+        failFastFailureRegexes: Collection<Regex>?,
 
         testBatchTimeoutMillis: Long?,
         testOutputTimeoutMillis: Long?,
@@ -122,6 +124,7 @@ data class Configuration constructor(
             includeSerialRegexes = includeSerialRegexes ?: emptyList(),
             excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),
             ignoreFailureRegexes = ignoreFailureRegexes ?: emptyList(),
+            failFastFailureRegexes = failFastFailureRegexes ?: emptyList(),
             testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,
             testOutputTimeoutMillis = testOutputTimeoutMillis ?: DEFAULT_OUTPUT_TIMEOUT_MILLIS,
             noDevicesTimeoutMillis = noDevicesTimeoutMillis ?: DEFAULT_NO_DEVICES_TIMEOUT_MILLIS,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/StrictRunChecker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/StrictRunChecker.kt
@@ -4,6 +4,7 @@ import com.malinskiy.marathon.test.Test
 
 interface StrictRunChecker {
     fun isStrictRun(test: Test): Boolean
+    fun hasFailFastFailures(stackTrace: String? = null) : Boolean
 }
 
 class ConfigurationStrictRunChecker(private val configuration: Configuration) : StrictRunChecker {
@@ -11,4 +12,6 @@ class ConfigurationStrictRunChecker(private val configuration: Configuration) : 
     override fun isStrictRun(test: Test): Boolean =
         configuration.strictMode || configuration.strictRunFilterConfiguration.filter.matches(test)
 
+    override fun hasFailFastFailures(stackTrace: String?): Boolean =
+        stackTrace?.let { configuration.failFastFailureRegexes.any { it.matches(stackTrace) } } == true
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -74,12 +74,15 @@ class QueueActor(
                     pool.send(FromQueue.Notify)
                 }
             }
+
             is QueueMessage.RequestBatch -> {
                 onRequestBatch(msg.device)
             }
+
             is QueueMessage.IsEmpty -> {
                 msg.deferred.complete(queue.isEmpty() && activeBatches.isEmpty())
             }
+
             is QueueMessage.Stop -> {
                 stopRequested = true
 
@@ -88,12 +91,15 @@ class QueueActor(
                     terminate()
                 }
             }
+
             is QueueMessage.Terminate -> {
                 onTerminate()
             }
+
             is QueueMessage.Completed -> {
                 onBatchCompleted(msg.device, msg.results)
             }
+
             is QueueMessage.ReturnBatch -> {
                 onReturnBatch(msg.device, msg.batch)
             }
@@ -129,19 +135,37 @@ class QueueActor(
                 logger.warn { "no logs for batch = $batchId" }
             }
 
+        val (failedFromUncompleted, uncompleted) = results
+            .uncompleted
+            .partitionFastFailures(batchLogs)
+
+        failedFromUncompleted.forEach {
+            logger.warn { "uncompleted test run marked as failed for ${it.test.toTestName()} as error message matches to fast test failures" }
+        }
+
         val (newUncompleted, failed) = results
             .failed
             .partitionIgnoredFailures(batchLogs)
 
         newUncompleted.forEach {
-            logger.debug { "Test run marked as uncompleted for ${it.test.toTestName()} as error message matches to ignored test failures" }
+            logger.debug { "failed test run marked as uncompleted for ${it.test.toTestName()} as error message matches to ignored test failures" }
         }
 
         return results.copy(
-            failed = failed,
-            uncompleted = results.uncompleted + newUncompleted
+            failed = failed + failedFromUncompleted,
+            uncompleted = uncompleted + newUncompleted
         )
     }
+
+    private fun Iterable<TestResult>.partitionFastFailures(batchLogs: BatchLogs?): Pair<List<TestResult>, List<TestResult>> =
+        partition {
+            if (it.hasFailFastFailureStackTrace()) {
+                true
+            } else {
+                val log = batchLogs?.tests?.get(it.test.toLogTest())
+                log?.hasFailFastFailureCrashLogEvent() ?: false
+            }
+        }
 
     private fun Iterable<TestResult>.partitionIgnoredFailures(batchLogs: BatchLogs?): Pair<List<TestResult>, List<TestResult>> =
         partition {
@@ -160,14 +184,39 @@ class QueueActor(
             }
             ?: false
 
+    private fun TestResult.hasFailFastFailureStackTrace(): Boolean =
+        stacktrace
+            ?.let { stacktrace ->
+                configuration.failFastFailureRegexes.any { regexp -> regexp.matches(stacktrace) }
+            }
+            ?: false
+
     private fun Log.hasIgnoredCrashLogEvent(): Boolean =
         events
             .any { logEvent ->
                 logEvent is LogEvent.Crash && configuration.ignoreFailureRegexes.any { regexp -> regexp.matches(logEvent.message) }
             }
 
+    private fun Log.hasFailFastFailureCrashLogEvent(): Boolean =
+        events
+            .any { logEvent ->
+                logEvent is LogEvent.Crash && configuration.failFastFailureRegexes.any { regexp -> regexp.matches(logEvent.message) }
+            }
+
     private fun handleUncompletedTests(uncompletedTests: Collection<TestResult>, device: DeviceInfo) {
-        val (uncompletedRetryQuotaExceeded, uncompleted) = uncompletedTests.partition {
+        val (uncompletedFailFastFailed, uncompletedCleaned) = uncompletedTests.partition { it.hasFailFastFailureStackTrace() }
+
+        if (uncompletedFailFastFailed.isNotEmpty()) {
+            logger.debug { "uncompleted test failed because of stacktrace for ${uncompletedFailFastFailed.joinToString(separator = ", ") { it.test.toTestName() }}" }
+            val uncompletedToFailed = uncompletedFailFastFailed.map {
+                it.copy(status = TestStatus.FAILURE)
+            }
+            for (test in uncompletedToFailed) {
+                testResultReporter.testIncomplete(device, test, final = true)
+            }
+        }
+
+        val (uncompletedRetryQuotaExceeded, uncompleted) = uncompletedCleaned.partition {
             (uncompletedTestsRetryCount[it.test] ?: 0) >= configuration.uncompletedTestRetryQuota
         }
 
@@ -250,8 +299,8 @@ class QueueActor(
         val retryList = retry
             .process(poolId, failed, flakyTests)
             .filter {
-                // strict run tests should not be re-run
-                !strictRunChecker.isStrictRun(it.test)
+                // strict run tests and tests with fail fast failure stack traces should not be re-run in a batch
+                !strictRunChecker.isStrictRun(it.test) && !strictRunChecker.hasFailFastFailures(it.stacktrace)
             }
 
         progressReporter.addRetries(poolId, retryList.size)

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/ConfigurationFactory.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/ConfigurationFactory.kt
@@ -62,6 +62,7 @@ private fun createConfiguration(
     includeSerialRegexes = extensionConfig.includeSerialRegexes?.map { it.toRegex() },
     excludeSerialRegexes = extensionConfig.excludeSerialRegexes?.map { it.toRegex() },
     ignoreFailureRegexes = extensionConfig.ignoreFailureRegexes?.map { it.toRegex(RegexOption.DOT_MATCHES_ALL) },
+    failFastFailureRegexes = extensionConfig.failFastFailureRegexes?.map { it.toRegex(RegexOption.DOT_MATCHES_ALL) },
     testBatchTimeoutMillis = extensionConfig.testBatchTimeoutMillis,
     testOutputTimeoutMillis = extensionConfig.testOutputTimeoutMillis,
     noDevicesTimeoutMillis = extensionConfig.noDevicesTimeoutMillis,

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -33,6 +33,13 @@ open class MarathonExtension {
     var excludeSerialRegexes: Collection<String>? = null
     var ignoreFailureRegexes: Collection<String>? = null
 
+    /**
+     * Tests that have failed with stack traces that match that property wouldn't be rerun
+     * It applies to both failed and uncompleted tests
+     * This has higher priority than uncompletedRetriesQuota or amount of runs in StrictRunFilterPluginConfiguration
+     */
+    var failFastFailureRegexes: Collection<String>? = null
+
     var testBatchTimeoutMillis: Long? = null
     var testOutputTimeoutMillis: Long? = null
     var noDevicesTimeoutMillis: Long? = null

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -132,7 +132,7 @@ class TestRunResultsListener(
         /**
          * If we explicitly requested parameterized tests - skip merging
          */
-        if(testBatch.tests.any { it.method.contains('[') && it.method.contains(']') }) return results
+        if (testBatch.tests.any { it.method.contains('[') && it.method.contains(']') }) return results
 
         val result = mutableMapOf<Test, AndroidTestResult>()
         for (e in results) {

--- a/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
+++ b/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
@@ -42,6 +42,7 @@ class AndroidTestParserSpek : Spek(
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
                     ignoreFailureRegexes = null,
+                    failFastFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
@@ -75,6 +75,7 @@ class AndroidDeviceTestRunnerSpek : Spek(
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
                     ignoreFailureRegexes = null,
+                    failFastFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
@@ -93,6 +93,7 @@ object DerivedDataManagerSpek : Spek(
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
                     ignoreFailureRegexes = null,
+                    failFastFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
@@ -45,6 +45,7 @@ object IOSTestParserSpek : Spek(
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,
                     ignoreFailureRegexes = null,
+                    failFastFailureRegexes = null,
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     noDevicesTimeoutMillis = null,

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
@@ -40,6 +40,7 @@ class ConfigurationFactory {
     var analyticsConfiguration: AnalyticsConfiguration? = null
     var excludeSerialRegexes: List<Regex>? = null
     var ignoreFailureRegexes: List<Regex>? = null
+    var failFastFailureRegexes: List<Regex>? = null
     var fallbackToScreenshots: Boolean? = null
     var strictMode: Boolean? = null
     var uncompletedTestRetryQuota: Int? = null
@@ -98,6 +99,7 @@ class ConfigurationFactory {
             includeSerialRegexes = includeSerialRegexes,
             excludeSerialRegexes = excludeSerialRegexes,
             ignoreFailureRegexes = ignoreFailureRegexes,
+            failFastFailureRegexes = failFastFailureRegexes,
             testBatchTimeoutMillis = testBatchTimeoutMillis,
             testOutputTimeoutMillis = testOutputTimeoutMillis,
             noDevicesTimeoutMillis = noDevicesTimeoutMillis,


### PR DESCRIPTION
Added `failFastFailureRegexes` configuration property

- Tests that have failed with stack traces that match that property wouldn't be rerun
- It applies to both failed and uncompleted tests
- This has higher priority than uncompletedRetriesQuota or amount of strict runs