### PR TITLE
Fail with a meaningful exception when parsing a test without package …

### DIFF
--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/AndroidTestParser.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/AndroidTestParser.kt
@@ -27,6 +27,9 @@ class AndroidTestParser : TestParser {
             val packageAndClassName = split[0]
 
             val lastDotIndex = packageAndClassName.indexOfLast { c -> c == '.' }
+
+            if (lastDotIndex == -1) throw IllegalStateException("Can't parse package name for test $testName")
+
             val packageName = packageAndClassName.substring(0 until lastDotIndex)
             val className = packageAndClassName.substring(lastDotIndex + 1 until packageAndClassName.length)
 


### PR DESCRIPTION
Throw an exception when test has no package name so we report properly which test is causing it instead of a indexOutOfBounds one that might be difficult to track down