### PR TITLE
Fix for loosing test method annotations in test results

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -27,7 +27,7 @@ object Versions {
     val testContainers = "1.15.3"
     val jupiterEngine = "5.1.0"
     val scalr = "4.2"
-    val allureJava = "2.17.3"
+    val allureJava = "2.28.0"
     val allureEnvironment = "1.0.0"
     val mockitoKotlin = "4.0.0"
     val koin = "2.0.1"

--- a/core/src/integrationTest/kotlin/com/malinskiy/marathon/scenario/CacheScenarios.kt
+++ b/core/src/integrationTest/kotlin/com/malinskiy/marathon/scenario/CacheScenarios.kt
@@ -33,10 +33,6 @@ class CacheScenarios : Spek(
             container.stop()
         }
 
-        afterEachTest {
-            stopKoin()
-        }
-
         given("cache is enabled") {
             group("the first execution of the test") {
                 it("should execute the test") {
@@ -109,6 +105,8 @@ private fun TestBody.runMarathonWithOneTest(
     }
 
     marathon.runAsync()
+
+    stopKoin()
 
     output!!
 }

--- a/core/src/integrationTest/kotlin/com/malinskiy/marathon/scenario/CacheScenarios.kt
+++ b/core/src/integrationTest/kotlin/com/malinskiy/marathon/scenario/CacheScenarios.kt
@@ -18,7 +18,6 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.TestBody
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
 import org.koin.core.context.stopKoin
 import java.io.File
 
@@ -39,7 +38,7 @@ class CacheScenarios : Spek(
         }
 
         given("cache is enabled") {
-            on("the first execution of the test") {
+            group("the first execution of the test") {
                 it("should execute the test") {
                     val outputDir = runMarathonWithOneTest(
                         test = Test("test", "ExampleTest", "test", emptySet(), TestComponentInfo()),
@@ -54,7 +53,7 @@ class CacheScenarios : Spek(
                 }
             }
 
-            on("the second execution of the test") {
+            group("the second execution of the test") {
                 it("should restored the test from cache") {
                     runMarathonWithOneTest(
                         test = Test("test", "SimpleTest", "test", emptySet(), TestComponentInfo()),

--- a/core/src/main/kotlin/com/malinskiy/marathon/cache/gradle/GradleHttpCacheService.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/cache/gradle/GradleHttpCacheService.kt
@@ -33,7 +33,9 @@ class GradleHttpCacheService(private val configuration: RemoteCacheConfiguration
             try {
                 val response = httpClient.get(url = key.entryUrl())
                 if (response.status != HttpStatusCode.OK) {
-                    logger.warn("Got response status when loading cache entry for ${key.key} : ${response.status}")
+                    if (response.status != HttpStatusCode.NotFound) {
+                        logger.warn("Got response status when loading cache entry for ${key.key} : ${response.status}")
+                    }
                     false
                 } else {
                     reader.readFrom(response.bodyAsChannel())

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
@@ -19,7 +19,6 @@ import io.qameta.allure.Epic
 import io.qameta.allure.Feature
 import io.qameta.allure.FileSystemResultsWriter
 import io.qameta.allure.Issue
-import io.qameta.allure.LabelAnnotation
 import io.qameta.allure.Lead
 import io.qameta.allure.Owner
 import io.qameta.allure.Severity
@@ -158,9 +157,8 @@ class AllureReporter(
         findValue<SeverityLevel>(Severity::class.java.canonicalName)?.let { list.add(ResultsUtils.createSeverityLabel(it)) }
         findValue<String>(Owner::class.java.canonicalName)?.let { list.add(ResultsUtils.createOwnerLabel(it)) }
         findValue<String>(Lead::class.java.canonicalName)?.let { list.add(ResultsUtils.createLabel(ResultsUtils.LEAD_LABEL_NAME, it)) }
-        metaProperties.filter { it.name == LabelAnnotation::class.java.canonicalName }.forEach {
-            list.add(ResultsUtils.createLabel(it.values["name"] as String, it.values["value"] as String))
-        }
+        findValue<String>("io.qameta.allure.junit4.Tag")?.let { list.add(ResultsUtils.createTagLabel(it)) }
+        findValue<String>("io.qameta.allure.Layer")?.let { list.add(ResultsUtils.createLabel("layer", it)) }
 
         return list
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
@@ -19,6 +19,8 @@ import io.qameta.allure.Epic
 import io.qameta.allure.Feature
 import io.qameta.allure.FileSystemResultsWriter
 import io.qameta.allure.Issue
+import io.qameta.allure.LabelAnnotation
+import io.qameta.allure.Lead
 import io.qameta.allure.Owner
 import io.qameta.allure.Severity
 import io.qameta.allure.SeverityLevel
@@ -136,8 +138,8 @@ class AllureReporter(
             .setTrace(testResult.stacktrace)
 
         test.findValue<String>(Description::class.java.canonicalName)?.let { allureTestResult.setDescription(it) }
-        test.findValue<String>(Issue::class.java.canonicalName)?.let { allureTestResult.links.add(it.toLink()) }
-        test.findValue<String>(TmsLink::class.java.canonicalName)?.let { allureTestResult.links.add(it.toLink()) }
+        test.findValue<String>(Issue::class.java.canonicalName)?.let { allureTestResult.links.add(ResultsUtils.createIssueLink(it)) }
+        test.findValue<String>(TmsLink::class.java.canonicalName)?.let { allureTestResult.links.add(ResultsUtils.createTmsLink(it)) }
 
         allureTestResult.labels.addAll(test.getOptionalLabels())
 
@@ -155,15 +157,12 @@ class AllureReporter(
         findValue<String>(Story::class.java.canonicalName)?.let { list.add(ResultsUtils.createStoryLabel(it)) }
         findValue<SeverityLevel>(Severity::class.java.canonicalName)?.let { list.add(ResultsUtils.createSeverityLabel(it)) }
         findValue<String>(Owner::class.java.canonicalName)?.let { list.add(ResultsUtils.createOwnerLabel(it)) }
+        findValue<String>(Lead::class.java.canonicalName)?.let { list.add(ResultsUtils.createLabel(ResultsUtils.LEAD_LABEL_NAME, it)) }
+        metaProperties.filter { it.name == LabelAnnotation::class.java.canonicalName }.forEach {
+            list.add(ResultsUtils.createLabel(it.values["name"] as String, it.values["value"] as String))
+        }
 
         return list
-    }
-
-    private fun String.toLink(): io.qameta.allure.model.Link {
-        return io.qameta.allure.model.Link().also {
-            it.name = "Issue"
-            it.url = this
-        }
     }
 
     private inline fun <reified T> Test.findValue(name: String): T? {

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
@@ -16,7 +16,6 @@ import org.amshove.kluent.mock
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -69,7 +68,7 @@ object TestResultReporterSpec : Spek(
         }
 
         given("a reporter with a default config") {
-            on("success - failure - failure") {
+            group("success - failure - failure") {
                 it("should report success") {
                     val filter = filterDefault()
 
@@ -90,7 +89,7 @@ object TestResultReporterSpec : Spek(
                 }
             }
 
-            on("failure - failure - success") {
+            group("failure - failure - success") {
                 it("should report success") {
                     val filter = filterDefault()
 
@@ -113,7 +112,7 @@ object TestResultReporterSpec : Spek(
         }
 
         given("a reporter with a strict config") {
-            on("success - failure - failure") {
+            group("success - failure - failure") {
                 it("should report failure") {
                     val reporter = strictReporter()
 
@@ -134,7 +133,7 @@ object TestResultReporterSpec : Spek(
                 }
             }
 
-            on("failure - success - success") {
+            group("failure - success - success") {
                 it("should report failure") {
                     val filter = strictReporter()
 
@@ -157,7 +156,7 @@ object TestResultReporterSpec : Spek(
         }
 
         given("a reporter with a strict run filter when test matches filter") {
-            on("success - failure - failure") {
+            group("success - failure - failure") {
                 it("should report failure") {
                     val reporter = strictFilterReporter(filter = SimpleClassnameFilter(Regex.fromLiteral(test.clazz)))
 
@@ -178,7 +177,7 @@ object TestResultReporterSpec : Spek(
                 }
             }
 
-            on("failure - success - success") {
+            group("failure - success - success") {
                 it("should report failure") {
                     val reporter = strictFilterReporter(filter = SimpleClassnameFilter(Regex.fromLiteral(test.clazz)))
 
@@ -201,7 +200,7 @@ object TestResultReporterSpec : Spek(
         }
 
         given("a reporter with a strict run filter when test does not match filter") {
-            on("success - failure - failure") {
+            group("success - failure - failure") {
                 it("should report success") {
                     val reporter = strictFilterReporter(filter = SimpleClassnameFilter(Regex.fromLiteral("$^")))
 
@@ -222,7 +221,7 @@ object TestResultReporterSpec : Spek(
                 }
             }
 
-            on("failure - success - success") {
+            group("failure - success - success") {
                 it("should report success") {
                     val reporter = strictFilterReporter(filter = SimpleClassnameFilter(Regex.fromLiteral("$^")))
 

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -156,7 +156,7 @@ class TestRunResultsListener(
     }
 
     private fun Map.Entry<Test, AndroidTestResult>.toTestResult(device: Device): TestResult {
-        val testInstanceFromBatch = testBatch.tests.find { it.clazz == key.clazz && it.pkg == key.pkg && it.method == key.method }
+        val testInstanceFromBatch = testBatch.tests.find { it == key }
         val test = key
         val attachments = attachments[test] ?: emptyList<Attachment>()
 

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -156,7 +156,7 @@ class TestRunResultsListener(
     }
 
     private fun Map.Entry<Test, AndroidTestResult>.toTestResult(device: Device): TestResult {
-        val testInstanceFromBatch = testBatch.tests.find { "${it.pkg}.${it.clazz}" == key.clazz && it.method == key.method }
+        val testInstanceFromBatch = testBatch.tests.find { it.clazz == key.clazz && it.pkg == key.pkg && it.method == key.method }
         val test = key
         val attachments = attachments[test] ?: emptyList<Attachment>()
 

--- a/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
+++ b/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
@@ -8,7 +8,6 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
 import java.io.File
 
 class AndroidTestParserSpek : Spek(
@@ -16,7 +15,7 @@ class AndroidTestParserSpek : Spek(
         describe("android test parser") {
             val parser = AndroidTestParser()
 
-            on("android test apk") {
+            group("android test apk") {
                 val apkFile = File(javaClass.classLoader.getResource("android_test_1.apk").file)
                 val configuration = Configuration(
                     name = "",

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceProviderSpek.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceProviderSpek.kt
@@ -18,7 +18,7 @@ import java.time.Clock
 class AndroidDeviceProviderSpek : Spek(
     {
         given("A provider") {
-            on("terminate") {
+            group("terminate") {
                 it("should close the channel") {
                     val config = ConfigurationFactory().build()
                     val provider = DdmlibDeviceProvider(Track(), SystemTimer(Clock.systemDefaultZone()), config, mock(), mock(), mock(), mock(), mock())


### PR DESCRIPTION
* Fixed issue with finding right test in test batch - it caused to wrong usage of the test from DdmlibDeviceExtensionsKt.toTest which doesn't contain any annotations in the test - so AllureReporter can't extract information from them
* Replaced all remaining `on` with `group` in Spek tests, so they won't be missed from test runs (`on` prevents them to run)
* Don't warn on 404 status when loading test result from Gradle Http Cache
* Upgrade Allure to 2.28.0, add support for Lead annotation and for generic LabelAnnotation with custom name and value